### PR TITLE
Correct read and write ASCII STL file with InvariantCulture

### DIFF
--- a/Source/STL/Normal.cs
+++ b/Source/STL/Normal.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using QuantumConcepts.Common.Extensions;
+using System.Globalization;
 
 namespace QuantumConcepts.Formats.StereoLithography
 {
@@ -27,7 +28,9 @@ namespace QuantumConcepts.Formats.StereoLithography
         /// <summary>Returns the string representation of this <see cref="Normal"/>.</summary>
         public override string ToString()
         {
-            return "normal {0} {1} {2}".FormatString(this.X, this.Y, this.Z);
+            //return "normal {0} {1} {2}".FormatString(this.X, this.Y, this.Z);
+            return String.Format(CultureInfo.InvariantCulture, "normal {0} {1} {2}", this.X, this.Y, this.Z);
+
         }
 
         /// <summary>Reads a single <see cref="Normal"/> from the <paramref name="reader"/>.</summary>

--- a/Source/STL/Vertex.cs
+++ b/Source/STL/Vertex.cs
@@ -64,7 +64,8 @@ namespace QuantumConcepts.Formats.StereoLithography
         /// <summary>Returns the string representation of this <see cref="Vertex"/>.</summary>
         public override string ToString()
         {
-            return "vertex {0} {1} {2}".FormatString(this.X, this.Y, this.Z);
+            //return "vertex {0} {1} {2}".FormatString(this.X, this.Y, this.Z);
+            return String.Format(CultureInfo.InvariantCulture, "vertex {0} {1} {2}", this.X, this.Y, this.Z);
         }
 
         /// <summary>Determines whether or not this instance is the same as the <paramref name="other"/> instance.</summary>
@@ -103,13 +104,13 @@ namespace QuantumConcepts.Formats.StereoLithography
                 return null;
 
             //Parse the three coordinates.
-            if (!float.TryParse(match.Groups["X"].Value, numberStyle, CultureInfo.CurrentCulture, out x))
+            if (!float.TryParse(match.Groups["X"].Value, numberStyle, CultureInfo.InvariantCulture, out x))
                 throw new FormatException("Could not parse X coordinate \"{0}\" as a decimal.".FormatString(match.Groups["X"]));
 
-            if (!float.TryParse(match.Groups["Y"].Value, numberStyle, CultureInfo.CurrentCulture, out y))
+            if (!float.TryParse(match.Groups["Y"].Value, numberStyle, CultureInfo.InvariantCulture, out y))
                 throw new FormatException("Could not parse Y coordinate \"{0}\" as a decimal.".FormatString(match.Groups["Y"]));
 
-            if (!float.TryParse(match.Groups["Z"].Value, numberStyle, CultureInfo.CurrentCulture, out z))
+            if (!float.TryParse(match.Groups["Z"].Value, numberStyle, CultureInfo.InvariantCulture, out z))
                 throw new FormatException("Could not parse Z coordinate \"{0}\" as a decimal.".FormatString(match.Groups["Z"]));
 
             return new Vertex()

--- a/Source/Test/STLTests.cs
+++ b/Source/Test/STLTests.cs
@@ -117,7 +117,7 @@ namespace QuantumConcepts.Formats.StereoLithography.Test
         {
             STLDocument stl1 = new STLDocument("WriteString", new List<Facet>()
             {
-                new Facet(new Normal( 0, 0, 1), new List<Vertex>()
+                new Facet(new Normal( 0.23f, 0, 1), new List<Vertex>()
                 {
                     new Vertex( 0, 0, 0),
                     new Vertex(-10.123f, -10, 0),

--- a/Source/Test/STLTests.cs
+++ b/Source/Test/STLTests.cs
@@ -120,8 +120,8 @@ namespace QuantumConcepts.Formats.StereoLithography.Test
                 new Facet(new Normal( 0, 0, 1), new List<Vertex>()
                 {
                     new Vertex( 0, 0, 0),
-                    new Vertex(-10, -10, 0),
-                    new Vertex(-10, 0, 0)
+                    new Vertex(-10.123f, -10, 0),
+                    new Vertex(-10.123f, 0, 0)
                 }, 0)
             });
             STLDocument stl2 = null;


### PR DESCRIPTION
Correct read and write ASCII STL file with InvariantCulture to fix #13 for the non-english cultures.