### PR TITLE
fixed text file detection

### DIFF
--- a/Source/STL/STLDocument.cs
+++ b/Source/STL/STLDocument.cs
@@ -118,9 +118,11 @@ namespace QuantumConcepts.Formats.StereoLithography
         /// <returns>True if the <see cref="STLDocument"/> is text-based, otherwise false.</returns>
         public static bool IsText(Stream stream)
         {
+            // based on http://www.fabbers.com/tech/STL_Format#Sct_ASCII
             const string solid = "solid";
+            const string facet = "facet";
 
-            byte[] buffer = new byte[5];
+            byte[] buffer = new byte[1024]; //-- one problem is that solid title on the first line could exceed 1024 bytes but this is unlikely
             string header = null;
 
             //Reset the stream to tbe beginning and read the first few bytes, then reset the stream to the beginning again.
@@ -131,7 +133,8 @@ namespace QuantumConcepts.Formats.StereoLithography
             //Read the header as ASCII.
             header = Encoding.ASCII.GetString(buffer);
 
-            return solid.Equals(header, StringComparison.InvariantCultureIgnoreCase);
+            return solid.Equals(header, StringComparison.InvariantCultureIgnoreCase) &&
+                   facet.Equals(header, StringComparison.InvariantCultureIgnoreCase);
         }
 
         /// <summary>Determines if the <see cref="STLDocument"/> contained within the <paramref name="stream"/> is binary-based.</summary>


### PR DESCRIPTION
in some tested files the IsText function returned true for binary files because the "solid" term text header was present in both text and binary files. The "facet" term (present only in text files on second line) was included for correct text file detection. The tryBinaryIfTextFailed parameter (which could have been a workaround for this) was not used in the original solution.

Test files used at: [https://we.tl/ZXG32BY0AQ](https://we.tl/ZXG32BY0AQ)